### PR TITLE
fix bug: null namespace read from .kube/config

### DIFF
--- a/client/src/main/java/org/kubeflow/client/KubeflowClientFactory.java
+++ b/client/src/main/java/org/kubeflow/client/KubeflowClientFactory.java
@@ -80,6 +80,10 @@ public class KubeflowClientFactory {
    * @throws IOException
    */
   public static KubeflowClient newInstanceFromConfig(KubeConfig config) throws IOException {
-    return newInstance(Config.fromConfig(config), config.getNamespace());
+    String defaultNamespace = config.getNamespace();
+    if (defaultNamespace == null) {
+      defaultNamespace = JobConstants.DEFAULT_NAMESPACE;
+    }
+    return newInstance(Config.fromConfig(config), defaultNamespace);
   }
 }


### PR DESCRIPTION
If there is no `namespace` field in `.kube/config`, client set a `null` namespace to `KubeClient` which may cause `NullPointerException`.

Signed-off-by: JetMuffin <mofeng.cj@alibaba-inc.com>