### PR TITLE
Status values of API conventions are "Success" and "Failure"

### DIFF
--- a/client/src/main/java/org/kubeflow/client/KubeflowClient.java
+++ b/client/src/main/java/org/kubeflow/client/KubeflowClient.java
@@ -132,7 +132,7 @@ public class KubeflowClient {
     V1DeleteOptions options = new V1DeleteOptions();
     V1Status status =
         this.api.deleteNamespacedTFJob(name, namespace, options, null, null, null, null);
-    return status.getStatus().equals("success");
+    return status.getStatus().equals("Success");
   }
 
   /**


### PR DESCRIPTION
`deleteJob` always returns false due to `Status` field never equals to `success`.
The values of `Status` can be referenced here.
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties